### PR TITLE
Stitching utils

### DIFF
--- a/examples/server/gql2ts.js
+++ b/examples/server/gql2ts.js
@@ -4,4 +4,5 @@ const { gql2ts } = require("../.."); // graphqlade in your app
 gql2ts({
   root: __dirname,
   server: true,
+  useStitchingDirectives: true,
 });

--- a/examples/server/schema/_stitching.gql
+++ b/examples/server/schema/_stitching.gql
@@ -1,0 +1,8 @@
+directive @key(selectionSet: String!) on OBJECT
+directive @computed(selectionSet: String!) on FIELD_DEFINITION
+directive @merge(argsExpr: String, keyArg: String, keyField: String, key: [String!], additionalArgs: String) on FIELD_DEFINITION
+directive @canonical on OBJECT | INTERFACE | INPUT_OBJECT | UNION | ENUM | SCALAR | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+extend type Query {
+  _sdl: String!
+}

--- a/examples/server/src/generated/schema.ts
+++ b/examples/server/src/generated/schema.ts
@@ -209,6 +209,16 @@ export interface RQuery<TContext> {
     context: TContext,
     info: GraphQLResolveInfo
   ) => AsyncResult<Maybe<number>>;
+
+  /**
+   * (String)
+   */
+  _sdl?: (
+    source: TQuery,
+    args: Record<string, never>,
+    context: TContext,
+    info: GraphQLResolveInfo
+  ) => AsyncResult<string>;
 }
 
 export interface RBoss<TContext> {
@@ -1139,6 +1149,11 @@ export interface TQuery {
    * (ESNumber)
    */
   divide?: number;
+
+  /**
+   * (String)
+   */
+  _sdl: string;
 }
 
 export interface TBoss {
@@ -1767,6 +1782,47 @@ export enum T__DirectiveLocation {
    * Location adjacent to an input object field definition.
    */
   INPUT_FIELD_DEFINITION = "INPUT_FIELD_DEFINITION",
+}
+
+export interface KeyDirective {
+  /**
+   * (String)
+   */
+  selectionSet: string;
+}
+
+export interface ComputedDirective {
+  /**
+   * (String)
+   */
+  selectionSet: string;
+}
+
+export interface MergeDirective {
+  /**
+   * (String)
+   */
+  argsExpr?: string;
+
+  /**
+   * (String)
+   */
+  keyArg?: string;
+
+  /**
+   * (String)
+   */
+  keyField?: string;
+
+  /**
+   * (Array<String>)
+   */
+  key?: Array<string>;
+
+  /**
+   * (String)
+   */
+  additionalArgs?: string;
 }
 
 export interface TsDirective {

--- a/examples/server/src/main.ts
+++ b/examples/server/src/main.ts
@@ -15,6 +15,7 @@ export async function main(env: NodeJS.ProcessEnv) {
   const gqlServer = await GraphQLServer.bootstrap<MyContext>({
     root: `${__dirname}/..`,
     resolvers,
+    useStitchingDirectives: true,
     resolverErrorHandler(err) {
       // eslint-disable-next-line no-console
       console.error(err.stack);

--- a/package-lock.json
+++ b/package-lock.json
@@ -536,11 +536,12 @@
       }
     },
     "@graphql-tools/batch-execute": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.2.tgz",
-      "integrity": "sha512-ykB7RwDjdtR6MdBz6aB0/LzU8V0TJA93ziIWiQZRgC30oPye3ROUuxITMD3Trij6iFQyyuuecGm9GxM9oEvEcQ==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.3.tgz",
+      "integrity": "sha512-dvP1bM02/NSDuAS5A6sLIUUJgs0fuMSk3Ib2jc3pL7HG7jzm/IXfvPURs48pJlMnxcawjVDC8fLh1oWfjmoAGg==",
+      "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.9.1",
+        "@graphql-tools/utils": "8.10.0",
         "dataloader": "2.1.0",
         "tslib": "^2.4.0",
         "value-or-promise": "1.0.11"
@@ -549,18 +550,20 @@
         "tslib": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
         }
       }
     },
     "@graphql-tools/delegate": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.0.tgz",
-      "integrity": "sha512-Y7cvToqKWdNZIk+wqcc3A7lQ/tLMwHDor0q5TE44FRkcvY9cvwEXUi+u6gV9SQ89vLaGz/VaNYJmMAG0cdOyMg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.1.tgz",
+      "integrity": "sha512-U350Q2oYGvXhto+sD3RNqgYFh+GbUYim++JUsm+2bgr4f38AqyRJxm85Y2iGn00u4lyXSXf3AHfztdMU3hYyHQ==",
+      "dev": true,
       "requires": {
-        "@graphql-tools/batch-execute": "8.5.2",
-        "@graphql-tools/schema": "9.0.0",
-        "@graphql-tools/utils": "8.9.1",
+        "@graphql-tools/batch-execute": "8.5.3",
+        "@graphql-tools/schema": "9.0.1",
+        "@graphql-tools/utils": "8.10.0",
         "dataloader": "2.1.0",
         "tslib": "~2.4.0",
         "value-or-promise": "1.0.11"
@@ -569,33 +572,37 @@
         "tslib": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
         }
       }
     },
     "@graphql-tools/merge": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.2.tgz",
-      "integrity": "sha512-r8TFlDFA9N4hbkKbHCUK5pkiSnVUsB5AtcyhoY1d3b9zNa9CAYgxZMkKZgDJAf9ZTIqki9t0eOW/jn1H4MCFsg==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.3.tgz",
+      "integrity": "sha512-EfULshN2s2s2mhBwbV9WpGnoehRLe7eIMdZrKfHhxlBWOvtNUd3KSCN0PUdAMd7lj1jXUW9KYdn624JrVn6qzg==",
+      "dev": true,
       "requires": {
-        "@graphql-tools/utils": "8.9.1",
+        "@graphql-tools/utils": "8.10.0",
         "tslib": "^2.4.0"
       },
       "dependencies": {
         "tslib": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
         }
       }
     },
     "@graphql-tools/schema": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.0.tgz",
-      "integrity": "sha512-H1rlt0tptzYE1jnKGjfmMvvMCwsDTUgCy3Eam9agsPP4ZtHAcwijDx3BKKJaV1fDRV5ztz2aJ5Q7+4s/SMOYvQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.1.tgz",
+      "integrity": "sha512-Y6apeiBmvXEz082IAuS/ainnEEQrzMECP1MRIV72eo2WPa6ZtLYPycvIbd56Z5uU2LKP4XcWRgK6WUbCyN16Rw==",
+      "dev": true,
       "requires": {
-        "@graphql-tools/merge": "8.3.2",
-        "@graphql-tools/utils": "8.9.1",
+        "@graphql-tools/merge": "8.3.3",
+        "@graphql-tools/utils": "8.10.0",
         "tslib": "^2.4.0",
         "value-or-promise": "1.0.11"
       },
@@ -603,31 +610,35 @@
         "tslib": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
         }
       }
     },
     "@graphql-tools/stitching-directives": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/stitching-directives/-/stitching-directives-2.3.2.tgz",
-      "integrity": "sha512-Xv2vByEAmD5BOreukgIppKw1TB3wm521Cht1V3zYiE6AFlG6Ih90ov3RZoUyO0PdhuYcr5Yd5LB5GARRACGqKg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/stitching-directives/-/stitching-directives-2.3.3.tgz",
+      "integrity": "sha512-YdxKOKTrqUcRFg1mIo2p7s5ziS7kcHOkeWuTnUJE3xAHH8iZf1GkqlcVRKtWtsNO8OZgS8BlatGsJXwmcH8KBA==",
+      "dev": true,
       "requires": {
-        "@graphql-tools/delegate": "9.0.0",
-        "@graphql-tools/utils": "8.9.1",
+        "@graphql-tools/delegate": "9.0.1",
+        "@graphql-tools/utils": "8.10.0",
         "tslib": "^2.4.0"
       },
       "dependencies": {
         "tslib": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
         }
       }
     },
     "@graphql-tools/utils": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.1.tgz",
-      "integrity": "sha512-LHR7U4okICeUap+WV/T1FnLOmTr3KYuphgkXYendaBVO/DXKyc+TeOFBiN1LcEjPqCB8hO+0B0iTIO0cGqhNTA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.10.0.tgz",
+      "integrity": "sha512-yI+V373FdXQbYfqdarehn9vRWDZZYuvyQ/xwiv5ez2BbobHrqsexF7qs56plLRaQ8ESYpVAjMQvJWe9s23O0Jg==",
+      "dev": true,
       "requires": {
         "tslib": "^2.4.0"
       },
@@ -635,7 +646,8 @@
         "tslib": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
         }
       }
     },
@@ -2517,7 +2529,8 @@
     "dataloader": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
-      "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ=="
+      "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==",
+      "dev": true
     },
     "debug": {
       "version": "4.3.1",
@@ -5938,7 +5951,8 @@
     "value-or-promise": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
-      "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg=="
+      "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==",
+      "dev": true
     },
     "vary": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -535,6 +535,110 @@
         }
       }
     },
+    "@graphql-tools/batch-execute": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.2.tgz",
+      "integrity": "sha512-ykB7RwDjdtR6MdBz6aB0/LzU8V0TJA93ziIWiQZRgC30oPye3ROUuxITMD3Trij6iFQyyuuecGm9GxM9oEvEcQ==",
+      "requires": {
+        "@graphql-tools/utils": "8.9.1",
+        "dataloader": "2.1.0",
+        "tslib": "^2.4.0",
+        "value-or-promise": "1.0.11"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@graphql-tools/delegate": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.0.tgz",
+      "integrity": "sha512-Y7cvToqKWdNZIk+wqcc3A7lQ/tLMwHDor0q5TE44FRkcvY9cvwEXUi+u6gV9SQ89vLaGz/VaNYJmMAG0cdOyMg==",
+      "requires": {
+        "@graphql-tools/batch-execute": "8.5.2",
+        "@graphql-tools/schema": "9.0.0",
+        "@graphql-tools/utils": "8.9.1",
+        "dataloader": "2.1.0",
+        "tslib": "~2.4.0",
+        "value-or-promise": "1.0.11"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@graphql-tools/merge": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.2.tgz",
+      "integrity": "sha512-r8TFlDFA9N4hbkKbHCUK5pkiSnVUsB5AtcyhoY1d3b9zNa9CAYgxZMkKZgDJAf9ZTIqki9t0eOW/jn1H4MCFsg==",
+      "requires": {
+        "@graphql-tools/utils": "8.9.1",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@graphql-tools/schema": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.0.tgz",
+      "integrity": "sha512-H1rlt0tptzYE1jnKGjfmMvvMCwsDTUgCy3Eam9agsPP4ZtHAcwijDx3BKKJaV1fDRV5ztz2aJ5Q7+4s/SMOYvQ==",
+      "requires": {
+        "@graphql-tools/merge": "8.3.2",
+        "@graphql-tools/utils": "8.9.1",
+        "tslib": "^2.4.0",
+        "value-or-promise": "1.0.11"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@graphql-tools/stitching-directives": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/stitching-directives/-/stitching-directives-2.3.2.tgz",
+      "integrity": "sha512-Xv2vByEAmD5BOreukgIppKw1TB3wm521Cht1V3zYiE6AFlG6Ih90ov3RZoUyO0PdhuYcr5Yd5LB5GARRACGqKg==",
+      "requires": {
+        "@graphql-tools/delegate": "9.0.0",
+        "@graphql-tools/utils": "8.9.1",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@graphql-tools/utils": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.9.1.tgz",
+      "integrity": "sha512-LHR7U4okICeUap+WV/T1FnLOmTr3KYuphgkXYendaBVO/DXKyc+TeOFBiN1LcEjPqCB8hO+0B0iTIO0cGqhNTA==",
+      "requires": {
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -2409,6 +2513,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "dataloader": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
+      "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ=="
     },
     "debug": {
       "version": "4.3.1",
@@ -5825,6 +5934,11 @@
           "dev": true
         }
       }
+    },
+    "value-or-promise": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
+      "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -535,105 +535,6 @@
         }
       }
     },
-    "@graphql-tools/batch-execute": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-8.5.3.tgz",
-      "integrity": "sha512-dvP1bM02/NSDuAS5A6sLIUUJgs0fuMSk3Ib2jc3pL7HG7jzm/IXfvPURs48pJlMnxcawjVDC8fLh1oWfjmoAGg==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/utils": "8.10.0",
-        "dataloader": "2.1.0",
-        "tslib": "^2.4.0",
-        "value-or-promise": "1.0.11"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-tools/delegate": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-9.0.1.tgz",
-      "integrity": "sha512-U350Q2oYGvXhto+sD3RNqgYFh+GbUYim++JUsm+2bgr4f38AqyRJxm85Y2iGn00u4lyXSXf3AHfztdMU3hYyHQ==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/batch-execute": "8.5.3",
-        "@graphql-tools/schema": "9.0.1",
-        "@graphql-tools/utils": "8.10.0",
-        "dataloader": "2.1.0",
-        "tslib": "~2.4.0",
-        "value-or-promise": "1.0.11"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-tools/merge": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.3.3.tgz",
-      "integrity": "sha512-EfULshN2s2s2mhBwbV9WpGnoehRLe7eIMdZrKfHhxlBWOvtNUd3KSCN0PUdAMd7lj1jXUW9KYdn624JrVn6qzg==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/utils": "8.10.0",
-        "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-tools/schema": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.1.tgz",
-      "integrity": "sha512-Y6apeiBmvXEz082IAuS/ainnEEQrzMECP1MRIV72eo2WPa6ZtLYPycvIbd56Z5uU2LKP4XcWRgK6WUbCyN16Rw==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/merge": "8.3.3",
-        "@graphql-tools/utils": "8.10.0",
-        "tslib": "^2.4.0",
-        "value-or-promise": "1.0.11"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-tools/stitching-directives": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/stitching-directives/-/stitching-directives-2.3.3.tgz",
-      "integrity": "sha512-YdxKOKTrqUcRFg1mIo2p7s5ziS7kcHOkeWuTnUJE3xAHH8iZf1GkqlcVRKtWtsNO8OZgS8BlatGsJXwmcH8KBA==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/delegate": "9.0.1",
-        "@graphql-tools/utils": "8.10.0",
-        "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-          "dev": true
-        }
-      }
-    },
     "@graphql-tools/utils": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.10.0.tgz",
@@ -2525,12 +2426,6 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
-    },
-    "dataloader": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
-      "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==",
-      "dev": true
     },
     "debug": {
       "version": "4.3.1",
@@ -5947,12 +5842,6 @@
           "dev": true
         }
       }
-    },
-    "value-or-promise": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.11.tgz",
-      "integrity": "sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==",
-      "dev": true
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@graphql-tools/stitching-directives": "^2"
   },
   "devDependencies": {
+    "@graphql-tools/stitching-directives": "^2.3.3",
     "@koa/router": "^10.1.1",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",

--- a/package.json
+++ b/package.json
@@ -50,11 +50,9 @@
     "prettier": "^2",
     "typescript": "^4",
     "ws": "^8",
-    "@graphql-tools/stitching-directives": "^2",
     "@graphql-tools/utils": "^8"
   },
   "devDependencies": {
-    "@graphql-tools/stitching-directives": "^2.3.3",
     "@graphql-tools/utils": "^8.10.0",
     "@koa/router": "^10.1.1",
     "@types/cors": "^2.8.12",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "graphql": "^16",
     "prettier": "^2",
     "typescript": "^4",
-    "ws": "^8"
+    "ws": "^8",
+    "@graphql-tools/stitching-directives": "^2"
   },
   "devDependencies": {
     "@koa/router": "^10.1.1",

--- a/package.json
+++ b/package.json
@@ -50,10 +50,12 @@
     "prettier": "^2",
     "typescript": "^4",
     "ws": "^8",
-    "@graphql-tools/stitching-directives": "^2"
+    "@graphql-tools/stitching-directives": "^2",
+    "@graphql-tools/utils": "^8"
   },
   "devDependencies": {
     "@graphql-tools/stitching-directives": "^2.3.3",
+    "@graphql-tools/utils": "^8.10.0",
     "@koa/router": "^10.1.1",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",

--- a/src/codegen/CodeGenerator.ts
+++ b/src/codegen/CodeGenerator.ts
@@ -96,7 +96,9 @@ export interface CodeGeneratorCliOptions {
   logger?: LoggerLike;
 
   /*
-   *
+   * Create a _stitching.gql file with required directives
+   * and queries to stitch multiple services together.
+   * Best used together with the same flag on bootstrap
    */
   useStitchingDirectives?: boolean;
 }

--- a/src/codegen/CodeGenerator.ts
+++ b/src/codegen/CodeGenerator.ts
@@ -1,7 +1,6 @@
 import fs from "fs";
 import { validate } from "graphql";
 import * as path from "path";
-import { stitchingDirectives } from "@graphql-tools/stitching-directives";
 import { GraphQLIntrospector, IntrospectionRequestFn } from "../introspect";
 import { GraphQLReader } from "../read";
 import {
@@ -276,8 +275,11 @@ export class CodeGenerator {
   }
 
   getStitchingDirectiveDefinition() {
-    const { allStitchingDirectivesTypeDefs } = stitchingDirectives();
-    return `${allStitchingDirectivesTypeDefs}
+    return `
+directive @key(selectionSet: String!) on OBJECT
+directive @computed(selectionSet: String!) on FIELD_DEFINITION
+directive @merge(argsExpr: String, keyArg: String, keyField: String, key: [String!], additionalArgs: String) on FIELD_DEFINITION
+directive @canonical on OBJECT | INTERFACE | INPUT_OBJECT | UNION | ENUM | SCALAR | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 extend type Query {
   _sdl: String!

--- a/src/server/GraphQLSchemaManager.ts
+++ b/src/server/GraphQLSchemaManager.ts
@@ -17,6 +17,7 @@ import {
   isObjectType,
   isScalarType,
   isUnionType,
+  printSchema,
 } from "graphql";
 import { assertDefined, assertRecord, mergeResolvers, toError } from "../util";
 
@@ -103,6 +104,21 @@ export class GraphQLSchemaManager<TContext> {
         if (field.name.startsWith("__")) continue;
 
         if (!field.resolve) field.resolve = defaultFieldResolver;
+      }
+    }
+  }
+
+  protected setStitchingSdlResolver() {
+    this.setResolvers(this.stitchingResolver());
+  }
+
+  stitchingResolver(): ResolversInput<TContext> {
+    const schema = this.schema;
+    return {
+      Query: {
+        _sdl() {
+          return printSchema(schema);
+        }
       }
     }
   }

--- a/src/server/GraphQLSchemaManager.ts
+++ b/src/server/GraphQLSchemaManager.ts
@@ -17,8 +17,8 @@ import {
   isObjectType,
   isScalarType,
   isUnionType,
-  printSchema,
 } from "graphql";
+import { printSchemaWithDirectives } from "@graphql-tools/utils";
 import { assertDefined, assertRecord, mergeResolvers, toError } from "../util";
 
 export type ResolversInput<TContext> =
@@ -117,7 +117,7 @@ export class GraphQLSchemaManager<TContext> {
     return {
       Query: {
         _sdl() {
-          return printSchema(schema);
+          return printSchemaWithDirectives(schema);
         }
       }
     }

--- a/src/server/GraphQLServer.ts
+++ b/src/server/GraphQLServer.ts
@@ -54,7 +54,9 @@ export interface GraphQLServerBootstrapOptions<TContext>
   resolverErrorHandler?: ResolverErrorHandler<TContext>;
 
   /*
-   * 
+   * Adds a query resolver for the _sdl query required
+   * to use stitching directives with a stitching service.
+   * Best used together with the same flag on gql2ts
    */
   useStitchingDirectives?: boolean;
 }

--- a/src/server/GraphQLServer.ts
+++ b/src/server/GraphQLServer.ts
@@ -52,6 +52,11 @@ export interface GraphQLServerBootstrapOptions<TContext>
    * Resolver error handler.
    */
   resolverErrorHandler?: ResolverErrorHandler<TContext>;
+
+  /*
+   * 
+   */
+  useStitchingDirectives?: boolean;
 }
 
 export interface CreateContextFnOptions {
@@ -95,6 +100,10 @@ export class GraphQLServer<TContext> extends GraphQLSchemaManager<TContext> {
 
     if (options.resolverErrorHandler) {
       server.setResolverErrorHandler(options.resolverErrorHandler);
+    }
+
+    if (options.useStitchingDirectives) {
+      server.setStitchingSdlResolver();
     }
 
     return server;

--- a/test/codegen/gql2ts.test.ts
+++ b/test/codegen/gql2ts.test.ts
@@ -59,4 +59,18 @@ describe("The gql2ts function", () => {
     expect(logger.errors).toEqual([]);
     expect(logger.logs).toEqual(["got headers"]);
   });
+
+  it("should generate server-side code with stitching directives", async () => {
+    const logger = new TestLogger();
+
+    await gql2ts({
+      root: "examples/server",
+      server: true,
+      noExit: true,
+      useStitchingDirectives: true,
+      logger,
+    });
+
+    expect(logger.errors).toEqual([]);
+  });
 });

--- a/test/server/GraphQLServer.test.ts
+++ b/test/server/GraphQLServer.test.ts
@@ -93,4 +93,24 @@ describe("The GraphQLServer", () => {
       },
     });
   });
+
+  it("should resolve the _sdl query by default when using the useStitchingDirectives flag", async () => {
+    const gqlServer = await GraphQLServer.bootstrap<undefined>({
+      root: `${__dirname}/../../examples/server`,
+      createContext() {
+        return undefined;
+      },
+      useStitchingDirectives: true,
+    });
+
+    const result = execute({
+      schema: gqlServer.schema,
+      document: parse(`
+        { _sdl }
+      `),
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result as any).data._sdl).toBeDefined();
+  });
 });

--- a/test/util/watchRecursive.test.ts
+++ b/test/util/watchRecursive.test.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, rmdirSync, writeFileSync } from "fs";
-import { join } from "path";
+import { join, normalize } from "path";
 import { GraphQLReader, watchRecursive } from "../../src";
 import { TestLogger } from "../util";
 
@@ -61,7 +61,11 @@ describe("The watchRecursive function", () => {
 
     // TODO this used to be a strict array check but it was flaky;
     // switched to checking unique entries for now
-    expect(Array.from(new Set(callbacks)).sort()).toEqual(
+    expect(
+      Array.from(new Set(callbacks))
+        .sort()
+        .map((it) => normalize(it))
+    ).toEqual(
       [
         "/watchRecursive/bar",
         "/watchRecursive/foo",
@@ -71,7 +75,7 @@ describe("The watchRecursive function", () => {
         "/watchRecursive/foo/baz/test.txt",
         "/watchRecursive/foo/test.gql",
         "/watchRecursive/test.graphql",
-      ].map((it) => join(__dirname, it))
+      ].map((it) => normalize(join(__dirname, it)))
     );
   });
 });


### PR DESCRIPTION
Add flags to codegen and bootstrap scripts.

With these flags enabled, a new file should be generated for graphql servers, adding the type merging directives for graphq stitching, as well as a query that should return the whole GraphQL definition.

Generated file:
```
directive @key(selectionSet: String!) on OBJECT
directive @computed(selectionSet: String!) on FIELD_DEFINITION
directive @merge(argsExpr: String, keyArg: String, keyField: String, key: [String!], additionalArgs: String) on FIELD_DEFINITION
directive @canonical on OBJECT | INTERFACE | INPUT_OBJECT | UNION | ENUM | SCALAR | FIELD_DEFINITION | INPUT_FIELD_DEFINITION

extend type Query {
  _sdl: String!
}

```