### PR TITLE
Changes to continue with middlewares queued after graphql Handlers for koa & expressjs.

### DIFF
--- a/src/http/GraphQLHttpServer.ts
+++ b/src/http/GraphQLHttpServer.ts
@@ -84,6 +84,7 @@ export class GraphQLHttpServer<TContext> {
       const response = await this.execute(req);
 
       res.status(response.status).set(response.headers).json(response.body);
+      await next();
     } catch (err) {
       next(toError(err));
     }

--- a/src/http/GraphQLHttpServer.ts
+++ b/src/http/GraphQLHttpServer.ts
@@ -18,7 +18,7 @@ import {
   ExpressRequestLike,
   ExpressResponseLike,
 } from "./express";
-import { KoaContextLike } from "./koa";
+import { KoaContextLike, KoaNextFunctionLike } from "./koa";
 
 export interface GraphQLHttpServerOptions<TContext> {
   /**
@@ -92,15 +92,17 @@ export class GraphQLHttpServer<TContext> {
   // koa helpers
 
   koaHandler() {
-    return (ctx: KoaContextLike) => this.handleKoa(ctx);
+    return (ctx: KoaContextLike, next: KoaNextFunctionLike) =>
+      this.handleKoa(ctx, next);
   }
 
-  async handleKoa(ctx: KoaContextLike) {
+  async handleKoa(ctx: KoaContextLike, next: KoaNextFunctionLike) {
     const response = await this.execute(ctx.request);
 
     ctx.status = response.status;
     ctx.set(response.headers);
     ctx.body = response.body;
+    await next();
   }
 
   // execution

--- a/src/http/GraphQLHttpServer.ts
+++ b/src/http/GraphQLHttpServer.ts
@@ -84,7 +84,7 @@ export class GraphQLHttpServer<TContext> {
       const response = await this.execute(req);
 
       res.status(response.status).set(response.headers).json(response.body);
-      await next();
+      next();
     } catch (err) {
       next(toError(err));
     }
@@ -103,7 +103,10 @@ export class GraphQLHttpServer<TContext> {
     ctx.status = response.status;
     ctx.set(response.headers);
     ctx.body = response.body;
-    await next();
+
+    if (next) {
+      await next();
+    }
   }
 
   // execution

--- a/src/http/koa.ts
+++ b/src/http/koa.ts
@@ -12,3 +12,5 @@ export interface KoaContextLike {
   set: (headers: Record<string, string>) => unknown;
   body?: unknown;
 }
+
+export type KoaNextFunctionLike = () => Promise<unknown>;

--- a/test/http/express.test.ts
+++ b/test/http/express.test.ts
@@ -1,0 +1,174 @@
+import { Server } from "http";
+import express, { Express } from "express";
+import { MyContext } from "../../examples/server/src/MyContext";
+import { GraphQLServer } from "../../src";
+import { bootstrapExample } from "../util";
+
+describe("The GraphQLHttpServer exposed via Express", () => {
+  const url = "http://localhost:6000/graphql";
+
+  let gqlServer: GraphQLServer<MyContext>;
+  let app: Express;
+  let server: Server;
+
+  beforeAll(async () => {
+    gqlServer = await bootstrapExample();
+
+    app = express();
+
+    app.get("/graphql", gqlServer.http.expressHandler());
+    app.post("/graphql", express.json(), gqlServer.http.expressHandler());
+
+    server = app.listen(6000);
+  });
+
+  afterAll(() => {
+    if (server) server.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should be able to handle POST GraphQL requests", async () => {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        query: "{ praise }",
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8"
+    );
+
+    const json = await response.json();
+
+    expect(json).toEqual({
+      data: {
+        praise: "the sun!",
+      },
+    });
+  });
+
+  it("should be able to handle GET GraphQL requests", async () => {
+    const response = await fetch(`${url}?query={praise}`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8"
+    );
+
+    const json = await response.json();
+
+    expect(json).toEqual({
+      data: {
+        praise: "the sun!",
+      },
+    });
+  });
+
+  it("should reject unsupported methods", async () => {
+    const response = await fetch(url, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        query: `{ praise }`,
+        operationName: "String",
+      }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("should reject mutations via GET", async () => {
+    const response = await fetch(`${url}?query=mutation{youDied}`);
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8"
+    );
+
+    const json = await response.json();
+
+    expect(json).toEqual({
+      errors: [{ message: "Mutations are not allowed via GET" }],
+    });
+  });
+
+  it("should reject invalid queries", async () => {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        query: `{ invalid }`,
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8"
+    );
+
+    const json = await response.json();
+
+    expect(json).toEqual({
+      errors: [
+        {
+          locations: [
+            {
+              column: 3,
+              line: 1,
+            },
+          ],
+          message: 'Cannot query field "invalid" on type "Query".',
+        },
+      ],
+    });
+  });
+
+  it("should reject bad requests (e.g. no content-type) with status code 400", async () => {
+    const response = await fetch(url, {
+      method: "POST",
+      body: JSON.stringify({
+        query: `{ invalid }`,
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8"
+    );
+
+    const json = await response.json();
+
+    expect(json).toEqual({
+      errors: [{ message: "Invalid query, expected string" }],
+    });
+  });
+
+  it("should continue with any express middleware queued in after the graphql handler", async () => {
+    const postGraphqlHandlerMiddleware = jest.fn();
+    const anotherApp = express();
+
+    anotherApp.get(
+      "/graphql",
+      gqlServer.http.expressHandler(),
+      postGraphqlHandlerMiddleware
+    );
+
+    const anotherServer = anotherApp.listen(6002);
+
+    try {
+      const response = await fetch(
+        `http://localhost:6002/graphql?query={praise}`
+      );
+      expect(response.status).toBe(200);
+      expect(postGraphqlHandlerMiddleware).toBeCalledTimes(1);
+    } finally {
+      anotherServer.close();
+    }
+  });
+});


### PR DESCRIPTION
Adds tests for express-js handler.